### PR TITLE
[FEATURE] Add Error Filter By Backtrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,18 +48,21 @@ require 'give_back_my_traces'
 
 RSpec.configure do |config|
   config.around(:each) do |example|
-    GBMT.init
+    GBMT.init(
+      from: ENV.fetch("GBMT_BACKTRACE_FROM", Rails.root.to_s) # By default only print errors with a backtrace from your app
+    )
 
     example.call
 
     GBMT.clear
+    GBMT.stop
   end
 ```
 
 And then you can see the errors running it with some GBMT envs:
 
 ```
-GBMT_ENABLE=1 rspec spec/requests/my_action_spec.rb 2>&1 | head -10
+GBMT_ENABLE=1 rspec spec/requests/my_action_spec.rb
 ----------------------------------------------------
  Error: BaseError
  Message: Test error
@@ -72,6 +75,10 @@ GBMT_ENABLE=1 rspec spec/requests/my_action_spec.rb 2>&1 | head -10
    ...
 
 ```
+
+Also you can filter erros by their backtrace with `GBMT_BACKTRACE_FROM`, it could be any string/regexp that matches the first line in the backtrace, eg:
+
+`GBMT_ENABLE=1 GBMT_BACKTRACE_FROM='controllers/my_action_controller' rspec spec/requests/my_action_spec.rb`
 
 See more in the examples folder.
 

--- a/lib/give_back_my_traces/tracker.rb
+++ b/lib/give_back_my_traces/tracker.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module GiveBackMyTraces
+  # class responsible to handle errors that are occurring at Runtime
+  class Tracker
+    NO_OP = ->(_) {}
+
+    def initialize(filters: [], **options)
+      @filters = filters
+      @options = options
+    end
+
+    def call(error)
+      return unless valid?(error)
+
+      print_error(error)
+    end
+
+    private
+
+    attr_accessor :filters, :options
+
+    def valid?(error)
+      filters.all? { |filter| filter.call(error) }
+    end
+
+    def print_error(error)
+      warn GiveBackMyTraces::Helpers.pretty_format(error, **options)
+    end
+  end
+end

--- a/spec/give_back_my_traces/tracker_spec.rb
+++ b/spec/give_back_my_traces/tracker_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe GiveBackMyTraces::Tracker do
+  let(:instance) { described_class.new(filters: filters, **options) }
+
+  let(:filters) { [] }
+  let(:options) { {} }
+
+  let(:expected_backtrace) { "/home/foo/bar" }
+
+  before do
+    GiveBackMyTraces.config[:from] = expected_backtrace
+  end
+
+  describe "#call" do
+    subject(:call) { instance.call(error) }
+
+    before do
+      allow(GiveBackMyTraces::Helpers).to receive(:pretty_format)
+    end
+
+    context "with filters" do
+      let(:filters) do
+        [GiveBackMyTraces::FROM_BACKTRACE_FILTER]
+      end
+
+      context "with a valid error" do
+        let(:error) { instance_double(StandardError, backtrace: [expected_backtrace]) }
+
+        it "print the error" do
+          call
+
+          expect(GiveBackMyTraces::Helpers).to have_received(:pretty_format).with(error, **options)
+        end
+      end
+
+      context "with a invalid error" do
+        let(:error) { instance_double(StandardError, backtrace: ["/home/nop"]) }
+
+        it "print the error" do
+          call
+
+          expect(GiveBackMyTraces::Helpers).to_not have_received(:pretty_format)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Add `GBMT_BACKTRACE_FROM` and from to `GBMT.init`to filters the errors to be printed